### PR TITLE
remove the application cache

### DIFF
--- a/customfield/classes/category.php
+++ b/customfield/classes/category.php
@@ -150,47 +150,25 @@ class category extends persistent {
     }
 
     /**
-     * Clear the customfield fields_definitions cache
-     */
-    protected function clear_cache() {
-        $cache = \cache::make('core', 'customfield_fields_definitions');
-        $key = $this->get('component') . '+' . $this->get('area') . '+' . $this->get('itemid');
-        $cache->delete($key);
-    }
-
-    /**
-     * Clear cache before create
+     * Hook to execute after an update.
      *
-     * @return bool
-     * @throws \dml_exception
-     * @throws \moodle_exception
+     * @param bool $result Whether or not the update was successful.
+     * @return void
      */
-    protected function before_create() : bool {
-        $this->clear_cache();
-        return true;
-    }
-
-    /**
-     * Clear cache before update
-     *
-     * @param bool $result
-     *
-     * @return bool
-     */
-    protected function after_update($result) : bool {
-        $this->clear_cache();
-        return true;
+    protected function after_update($result) {
+        handler::get_handler_for_category($this)->clear_fields_definitions_cache();
     }
 
     /**
      * Updates sort order after create
      *
-     * @return bool
+     * @return void
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    protected function after_create() : bool {
-        return $this->reorder();
+    protected function after_create() {
+        handler::get_handler_for_category($this)->clear_fields_definitions_cache();
+        $this->reorder();
     }
 
     /**
@@ -201,7 +179,6 @@ class category extends persistent {
      * @throws \dml_exception
      */
     protected function before_delete() : bool {
-        $this->clear_cache();
         foreach ($this->fields() as $field) {
             if (!$field->delete()) {
                 return false;
@@ -214,12 +191,13 @@ class category extends persistent {
      * Update sort order after delete
      *
      * @param bool $result
-     * @return bool
+     * @return void
      * @throws \moodle_exception
      * @throws \dml_exception
      */
-    protected function after_delete($result) :bool {
-        return $this->reorder();
+    protected function after_delete($result) {
+        handler::get_handler_for_category($this)->clear_fields_definitions_cache();
+        $this->reorder();
     }
 
     /**
@@ -264,7 +242,6 @@ class category extends persistent {
             $this->set('sortorder', $this->get('sortorder') + $position);
             $this->save();
         }
-        $this->clear_cache();
         return $this;
     }
 
@@ -306,7 +283,6 @@ class category extends persistent {
             $categoryfrom->set('sortorder', -1);
             $categoryfrom->save();
             $output = $categoryfrom->reorder();
-            $categoryfrom->clear_cache();
             return $output;
         }
 

--- a/customfield/classes/handler.php
+++ b/customfield/classes/handler.php
@@ -63,6 +63,11 @@ abstract class handler {
     private $itemid;
 
     /**
+     * @var category[]
+     */
+    protected $fieldsdefinitions = null;
+
+    /**
      * Handler constructor.
      *
      * This constructor is protected. To initiate a class use an appropriate static method:
@@ -292,15 +297,14 @@ abstract class handler {
      * @return category[]
      */
     public function get_fields_definitions() : array {
-        $cache = \cache::make('core', 'customfield_fields_definitions');
-        $key = $this->get_component() . '+' . $this->get_area() . '+' . $this->get_itemid();
-        if ($data = $cache->get($key)) {
-            $fields = $data;
-        } else {
-            $fields = api::get_fields_definitions($this->get_component(), $this->get_area(), $this->get_itemid());
-            $cache->set($key, $fields);
+        if ($this->fieldsdefinitions === null) {
+            $this->fieldsdefinitions = api::get_fields_definitions($this->get_component(), $this->get_area(), $this->get_itemid());
         }
-        return $fields;
+        return $this->fieldsdefinitions;
+    }
+
+    public function clear_fields_definitions_cache() {
+        $this->fieldsdefinitions = null;
     }
 
     /**
@@ -461,6 +465,7 @@ abstract class handler {
     public function save_field(field $field, stdClass $data) {
         try {
             api::save_field($field, $data, $this->get_description_text_options());
+            $this->fieldsdefinitions = null;
             \core\notification::success(get_string('fieldsaved', 'core_customfield'));
         } catch (\moodle_exception $exception) {
             \core\notification::error(get_string('fieldsavefailed', 'core_customfield'));

--- a/lang/en/cache.php
+++ b/lang/en/cache.php
@@ -47,7 +47,6 @@ $string['cachedef_coursecompletion'] = 'Course completion status';
 $string['cachedef_coursecontacts'] = 'List of course contacts';
 $string['cachedef_coursemodinfo'] = 'Accumulated information about modules and sections for each course';
 $string['cachedef_completion'] = 'Activity completion status';
-$string['cachedef_customfield_fields_definitions'] = 'Definitions of custom fields';
 $string['cachedef_databasemeta'] = 'Database meta information';
 $string['cachedef_eventinvalidation'] = 'Event invalidation';
 $string['cachedef_externalbadges'] = 'External badges for particular user';

--- a/lib/db/caches.php
+++ b/lib/db/caches.php
@@ -387,8 +387,4 @@ $definitions = array(
             'createduser',
         )
     ),
-
-    'customfield_fields_definitions' => [
-        'mode' => cache_store::MODE_APPLICATION
-    ],
 );


### PR DESCRIPTION
using application cache makes no sense because retrieving from application cache uses the same one db query
as retrieving from the database.
Also the instance of the handler is cached, therefore we can use the the protected variable inside the handler
to store the cached fields definition

*** PLEASE DO NOT OPEN PULL REQUESTS VIA GITHUB ***

The moodle.git repository at Github is just a mirror of the official repository. We do not accept pull requests at Github.

See CONTRIBUTING.txt guidelines for how to contribute patches for Moodle. Thank you.

--
