### PR TITLE
Sp 3 master field controller - small fixes

### DIFF
--- a/course/edit_form.php
+++ b/course/edit_form.php
@@ -388,7 +388,7 @@ class course_edit_form extends moodleform {
             }
         }
 
-        // Add the custom fields.
+        // Tweak the form with values provided by custom fields in use.
         $handler  = core_course\customfield\course_handler::instance();
         $handler->definition_after_data($mform, $courseid);
     }

--- a/course/lib.php
+++ b/course/lib.php
@@ -2487,9 +2487,8 @@ function create_course($data, $editoroptions = NULL) {
         core_tag_tag::set_item_tags('core', 'course', $course->id, context_course::instance($course->id), $data->tags);
     }
 
-    // Save custom fields.
-    // This check if $data contains customfield_*.
-    if (strpos(implode('', array_keys(get_object_vars($data))), 'customfield')) {
+    // Save custom fields if there are any of them in the form.
+    if (count(preg_grep('/^customfield_/', array_keys((array)$data)))) {
         $handler = core_course\customfield\course_handler::instance();
         $data->id = $course->id;
         $data->contextid = $context->id;
@@ -2579,8 +2578,8 @@ function update_course($data, $editoroptions = NULL) {
         }
     }
 
-    // This check if $data contains customfield_*.
-    if (strpos(implode('', array_keys(get_object_vars($data))), 'customfield')) {
+    // Update custom fields if there are any of them in the form.
+    if (count(preg_grep('/^customfield_/', array_keys((array)$data)))) {
         $handler = core_course\customfield\course_handler::instance();
         $data->contextid = $context->id;
         $handler->save_customfield_data($data);

--- a/course/tests/behat/customfields_edit_settings.feature
+++ b/course/tests/behat/customfields_edit_settings.feature
@@ -1,4 +1,4 @@
-@core @core_course @core_customfield
+@core @core_course @core_customfield @aaa
 Feature: Teachers can edit course custom fields
   In order to have additional data on the course
   As a teacher
@@ -48,3 +48,26 @@ Feature: Teachers can edit course custom fields
     When I set the field "coursesearchbox" to "testcontent"
      And I press "Go"
     Then I should see "Course 1"
+
+  Scenario: Create a course from the management interface
+   When I log in as "admin"
+    And I go to the courses management page
+    And I should see the "Categories" management page
+    And I click on category "Miscellaneous" in the management interface
+    And I should see the "Course categories and courses" management page
+    And I click on "Create new course" "link" in the "#course-listing" "css_element"
+    When I set the following fields to these values:
+      | Course full name | Course 2 |
+      | Course short name | C2 |
+      | Format | topics |
+      | Test field | testcontent2 |
+    And I press "Save and return"
+    Then I should see the "Course categories and courses" management page
+    And I click on "Sort by Course time created ascending" "link" in the ".course-listing-actions" "css_element"
+    And I click on "Course 2" "link" in the "region-main" "region"
+    And I click on "Edit" "link" in the ".course-detail" "css_element"
+    And the following fields match these values:
+      | Course full name | Course 2 |
+      | Course short name | C2 |
+      | Format | topics |
+      | Test field | testcontent2 |

--- a/customfield/classes/handler.php
+++ b/customfield/classes/handler.php
@@ -315,6 +315,7 @@ abstract class handler {
     /**
      * List of fields with their data
      *
+     * @param array $fields
      * @param int $instanceid
      * @return data[]
      */
@@ -336,13 +337,20 @@ abstract class handler {
     }
 
     /**
-     * Custom fields definition after data was submitted on data form
+     * Form data definition callback.
+     *
+     * This method is called from moodleform::definition_after_data and allows to tweak
+     * mform with some data coming directly from the field plugin data controller.
      *
      * @param \MoodleQuickForm $mform
-     * @param int $instanceid
+     * @param int|null $instanceid
      * @throws \moodle_exception
      */
-    public function definition_after_data(\MoodleQuickForm $mform, int $instanceid) {
+    public function definition_after_data(\MoodleQuickForm $mform, $instanceid) {
+        if ($instanceid === null) {
+            // Course does not exist yet.
+            $instanceid = 0;
+        }
         $editablefields = $this->get_editable_fields($instanceid);
         $fields = $this->get_fields_with_data($editablefields, $instanceid);
 

--- a/lib/testing/generator/data_generator.php
+++ b/lib/testing/generator/data_generator.php
@@ -1192,7 +1192,7 @@ EOD;
      * @param   array $data Array with 'name', 'shortname' and 'type' of the field
      * @return  \stdClass   The created field
      */
-    public function create_custom_field($category, $data): \core_customfield\field {
+    public function create_custom_field($category, $data): \core_customfield\field_controller {
         $handler = core_course\customfield\course_handler::instance();
         $data['configdata'] = empty($data['configdata']) ? [] : $data['configdata'];
         $field = $handler->new_field($category, $data['type']);


### PR DESCRIPTION
Hi Toni, there is one fix here and another commit is my simplified suggestion how to determine presence of "customfiled_" in the form fields object. When we know that form data is a simple stdClass with variables only, I think get_object_vars adds  a bit overhead (as it checks for variable visibility as well). Also, while concatenation and strpos is a good idea in some cases, there is preg_grep function we can use to make code easier to read :) 